### PR TITLE
Fix CI branch name and clean up artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
This cleans up some build artifacts and corrects the default branch name for CI.

Fixes https://mattermost.atlassian.net/browse/CLD-8416

