### PR TITLE
Update pgEdge config to support 1.0

### DIFF
--- a/cmd/mmdbt/config.go
+++ b/cmd/mmdbt/config.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost-dbt/model"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	configCmd.Flags().String("pgedge-config", "", "The location of the pgEdge config file")
+	configCmd.Flags().Bool("sanitize", true, "Sanitize sensitive config values before printing")
+}
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Prints pgEdge cluster config",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		configLocation, _ := command.Flags().GetString("pgedge-config")
+		config, err := model.NewClusterConfigFromFile(configLocation)
+		if err != nil {
+			return err
+		}
+
+		sanitize, _ := command.Flags().GetBool("sanitize")
+		if sanitize {
+			config.Pgedge.Sanitize()
+		}
+
+		fmt.Println("")
+		fmt.Println("CONFIG")
+		fmt.Println("================================================")
+		printJSON(config)
+
+		return nil
+	},
+}

--- a/cmd/mmdbt/main.go
+++ b/cmd/mmdbt/main.go
@@ -16,6 +16,7 @@ func init() {
 	viper.SetEnvPrefix("MMDBT")
 	viper.AutomaticEnv()
 
+	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(monitorCmd)
 	rootCmd.AddCommand(verifyIndexesCmd)
 	rootCmd.AddCommand(versionCmd)

--- a/internal/store/pgedge.go
+++ b/internal/store/pgedge.go
@@ -20,8 +20,8 @@ type PgedgeNodeStore struct {
 
 func NewStoreForPgedgeNode(db *model.PgedgeDatabase, node *model.PgedgeNode, logger log.FieldLogger) (*SQLStore, error) {
 	dsn := fmt.Sprintf(
-		"postgres://%s:%s@%s:%d/%s?connect_timeout=10&sslmode=disable",
-		db.Username, db.Password, node.IPAddress, node.Port, db.Name,
+		"postgres://%s:%s@%s:%s/%s?connect_timeout=10&sslmode=disable",
+		db.Username, db.Password, node.PublicIP, node.Port, db.Name,
 	)
 
 	store, err := New(dsn, logger)
@@ -38,20 +38,20 @@ func NewStoreForPgedgeNode(db *model.PgedgeDatabase, node *model.PgedgeNode, log
 }
 
 func NewStoresForAllPgedgeNodes(pgedgeConfig *model.PgedgeClusterConfig, logger log.FieldLogger) ([]*PgedgeNodeStore, error) {
-	nodes := pgedgeConfig.NodeGroups.Nodes()
+	nodes := pgedgeConfig.NodeGroups
 	if len(nodes) == 0 {
 		return nil, errors.New("config contains no database nodes")
 	}
 
 	var nodesStores []*PgedgeNodeStore
 	for _, node := range nodes {
-		store, err := NewStoreForPgedgeNode(pgedgeConfig.Database.Databases[0], &node, logger)
+		store, err := NewStoreForPgedgeNode(pgedgeConfig.Pgedge.Databases[0], node, logger)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create store for pgEdge node %s", node.Name)
 		}
 
 		nodesStores = append(nodesStores, &PgedgeNodeStore{
-			&node,
+			node,
 			store,
 		})
 	}

--- a/model/pgedge_config.go
+++ b/model/pgedge_config.go
@@ -6,71 +6,60 @@ import (
 )
 
 type PgedgeClusterConfig struct {
-	Name       string                 `json:"name"`
-	Style      string                 `json:"style"`
-	CreateDate string                 `json:"create_date"`
-	Remote     PgedgeHostConfig       `json:"remote,omitempty"`
-	LocalHost  PgedgeHostConfig       `json:"localhost,omitempty"`
-	Database   PgedgeDatabaseConfig   `json:"database"`
-	NodeGroups PgedgeNodeGroupsConfig `json:"node_groups"`
-}
-
-type PgedgeHostConfig struct {
-	OSUser string `json:"os_user"`
-	SSHKey string `json:"ssh_key"`
+	JSONVersion string                `json:"json_version"`
+	ClusterName string                `json:"cluster_name"`
+	LogLevel    string                `json:"log_level"`
+	UpdateDate  string                `json:"update_date"`
+	Pgedge      *PgedgeDatabaseConfig `json:"pgedge"`
+	NodeGroups  []*PgedgeNode         `json:"node_groups"`
 }
 
 type PgedgeDatabaseConfig struct {
-	Databases []*PgedgeDatabase `json:"databases"`
 	PgVersion int               `json:"pg_version"`
-	AutoDDL   string            `json:"auto_ddl"`
 	AutoStart string            `json:"auto_start"`
+	Spock     *SpockConfig      `json:"spock"`
+	Databases []*PgedgeDatabase `json:"databases"`
+}
+
+type SpockConfig struct {
+	SpockVersion string `json:"spock_version"`
+	AutoDDL      string `json:"auto_ddl"`
 }
 
 type PgedgeDatabase struct {
-	Name     string `json:"name"`
-	Username string `json:"username"`
-	Password string `json:"password"`
-}
-
-type PgedgeNodeGroupsConfig struct {
-	Remote    []PgedgeLocalhostNodes `json:"remote,omitempty"`
-	Localhost []PgedgeLocalhostNodes `json:"localhost,omitempty"`
-}
-
-type PgedgeLocalhostNodes struct {
-	Nodes []PgedgeNode `json:"nodes"`
+	Name     string `json:"db_name"`
+	Username string `json:"db_user"`
+	Password string `json:"db_password"`
 }
 
 type PgedgeNode struct {
-	Name      string `json:"name"`
-	IsActive  bool   `json:"is_active"`
-	IPAddress string `json:"ip_address"`
-	Port      int    `json:"port"`
-	Path      string `json:"path"`
+	SSH       *PgedgeHostConfig `json:"ssh"`
+	Name      string            `json:"name"`
+	IsActive  string            `json:"is_active"`
+	PublicIP  string            `json:"public_ip"`
+	PrivateIP string            `json:"private_ip"`
+	Port      string            `json:"port"`
+	Path      string            `json:"path"`
+	Backrest  *PgedgeBackrest   `json:"backrest"`
+}
+
+type PgedgeHostConfig struct {
+	OSUser     string `json:"os_user"`
+	PrivateKey string `json:"private_key"`
+}
+
+type PgedgeBackrest struct {
+	Stanza            string `json:"stanza"`
+	RepoPath          string `json:"repo1-path"`
+	RepoRetentionFull string `json:"repo1-retention-full"`
+	LogLevelConsole   string `json:"log-level-console"`
+	RepoCypherType    string `json:"repo1-cipher-type"`
 }
 
 func (dbc *PgedgeDatabaseConfig) Sanitize() {
 	for _, database := range dbc.Databases {
 		database.Sanitize()
 	}
-}
-
-func (ng *PgedgeNodeGroupsConfig) Nodes() []PgedgeNode {
-	var nodes []PgedgeNode
-
-	if len(ng.Remote) != 0 {
-		for _, l := range ng.Remote {
-			nodes = append(nodes, l.Nodes...)
-		}
-		return nodes
-	}
-
-	for _, l := range ng.Localhost {
-		nodes = append(nodes, l.Nodes...)
-	}
-
-	return nodes
 }
 
 func (db *PgedgeDatabase) Sanitize() {

--- a/model/pgedge_config_test.go
+++ b/model/pgedge_config_test.go
@@ -11,50 +11,65 @@ import (
 func TestNewClusterConfigFromBytes(t *testing.T) {
 	configString := `
 {
-    "name": "test1",
-    "style": "localhost",
-    "create_date": "2024-01-01",
-    "localhost": {
-      "os_user": "ubuntu",
-      "ssh_key": ""
-    },
-    "database": {
-      "databases": [
-        {
-          "username": "testusername",
-          "password": "testpassword",
-          "name": "mattermost"
-        }
-      ],
-      "pg_version": 14,
+  "json_version": "1.0",
+  "cluster_name": "test1",
+  "log_level": "debug",
+  "update_date": "2024-1-1 01:01:01 GMT",
+  "pgedge": {
+    "pg_version": 14,
+    "auto_start": "off",
+    "spock": {
+      "spock_version": "",
       "auto_ddl": "on"
     },
-    "node_groups": {
-      "localhost": [
-        {
-          "nodes": [
-            {
-              "name": "n1",
-              "is_active": true,
-              "ip_address": "127.0.0.1",
-              "port": 7432,
-              "path": "/home/ubuntu/pgedge/cluster/test1/n1"
-            }
-          ]
-        },
-        {
-          "nodes": [
-            {
-              "name": "n2",
-              "is_active": true,
-              "ip_address": "127.0.0.1",
-              "port": 7433,
-              "path": "/home/ubuntu/pgedge/cluster/test1/n2"
-            }
-          ]
-        }
-      ]
+    "databases": [
+      {
+        "db_name": "mattermost",
+        "db_user": "testusername",
+        "db_password": "testpassword"
+      }
+    ]
+  },
+  "node_groups": [
+    {
+      "ssh": {
+        "os_user": "ubuntu",
+        "private_key": ""
+      },
+      "name": "n1",
+      "is_active": "on",
+      "public_ip": "127.0.0.1",
+      "private_ip": "127.0.0.1",
+      "port": "7432",
+      "path": "/home/ubuntu/pgedge/cluster/test1/n1",
+      "backrest": {
+        "stanza": "test1_stanza",
+        "repo1-path": "/var/lib/pgbackrest",
+        "repo1-retention-full": "7",
+        "log-level-console": "info",
+        "repo1-cipher-type": "aes-256-cbc"
+      }
+    },
+    {
+      "ssh": {
+        "os_user": "ubuntu",
+        "private_key": ""
+      },
+      "name": "n2",
+      "is_active": "on",
+      "public_ip": "127.0.0.1",
+      "private_ip": "127.0.0.1",
+      "port": "7433",
+      "path": "/home/ubuntu/pgedge/cluster/test1/n2",
+      "backrest": {
+        "stanza": "test1_stanza",
+        "repo1-path": "/var/lib/pgbackrest",
+        "repo1-retention-full": "7",
+        "log-level-console": "info",
+        "repo1-cipher-type": "aes-256-cbc"
+      }
     }
+  ]
 }`
 
 	config, err := model.NewClusterConfigFromBytes([]byte(configString))
@@ -62,23 +77,24 @@ func TestNewClusterConfigFromBytes(t *testing.T) {
 	require.NotNil(t, config)
 
 	t.Run("metadata", func(t *testing.T) {
-		assert.Equal(t, "test1", config.Name)
-		assert.Equal(t, "localhost", config.Style)
-		assert.Equal(t, "2024-01-01", config.CreateDate)
+		assert.Equal(t, "test1", config.ClusterName)
+		assert.Equal(t, "1.0", config.JSONVersion)
+		assert.Equal(t, "2024-1-1 01:01:01 GMT", config.UpdateDate)
+		assert.Equal(t, "debug", config.LogLevel)
 	})
 
 	t.Run("databases", func(t *testing.T) {
-		require.Len(t, config.Database.Databases, 1)
-		assert.Equal(t, "mattermost", config.Database.Databases[0].Name)
-		assert.Equal(t, "testusername", config.Database.Databases[0].Username)
-		assert.Equal(t, "testpassword", config.Database.Databases[0].Password)
+		require.Len(t, config.Pgedge.Databases, 1)
+		assert.Equal(t, "mattermost", config.Pgedge.Databases[0].Name)
+		assert.Equal(t, "testusername", config.Pgedge.Databases[0].Username)
+		assert.Equal(t, "testpassword", config.Pgedge.Databases[0].Password)
 
-		config.Database.Sanitize()
-		assert.NotEqual(t, "testpassword", config.Database.Databases[0].Password)
+		config.Pgedge.Sanitize()
+		assert.NotEqual(t, "testpassword", config.Pgedge.Databases[0].Password)
 	})
 
 	t.Run("nodes", func(t *testing.T) {
-		nodes := config.NodeGroups.Nodes()
+		nodes := config.NodeGroups
 		require.Len(t, nodes, 2)
 		assert.Equal(t, "n1", nodes[0].Name)
 		assert.Equal(t, "n2", nodes[1].Name)


### PR DESCRIPTION
This change updates the pgEdge config parsing to support 1.0 of the config schema. A new command is also added to print the parsed config via the CLI.

Fixes https://mattermost.atlassian.net/browse/CLD-8471 and https://mattermost.atlassian.net/browse/CLD-8472

