### PR TITLE
Add functionality to create missing database indexes

### DIFF
--- a/cmd/mmdbt/verify_index.go
+++ b/cmd/mmdbt/verify_index.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	verifyIndexesCmd.Flags().String("pgedge-config", "", "The location of the pgEdge config file")
 	verifyIndexesCmd.Flags().String("schema-name", "public", "The database schema to compare indexes on")
-	verifyIndexesCmd.Flags().Bool("fix-missing", true, "Create missing indexes")
+	verifyIndexesCmd.Flags().Bool("fix-missing", false, "Create missing indexes")
 }
 
 var verifyIndexesCmd = &cobra.Command{

--- a/cmd/mmdbt/verify_index.go
+++ b/cmd/mmdbt/verify_index.go
@@ -16,6 +16,7 @@ import (
 func init() {
 	verifyIndexesCmd.Flags().String("pgedge-config", "", "The location of the pgEdge config file")
 	verifyIndexesCmd.Flags().String("schema-name", "public", "The database schema to compare indexes on")
+	verifyIndexesCmd.Flags().Bool("fix-missing", true, "Create missing indexes")
 }
 
 var verifyIndexesCmd = &cobra.Command{
@@ -30,6 +31,7 @@ var verifyIndexesCmd = &cobra.Command{
 			return err
 		}
 
+		fixMissing, _ := command.Flags().GetBool("fix-missing")
 		schemaName, _ := command.Flags().GetString("schema-name")
 		indexFilter := &model.PgIndexFilter{SchemaName: schemaName}
 
@@ -65,6 +67,19 @@ var verifyIndexesCmd = &cobra.Command{
 					logger.Info("All indexes found")
 				} else {
 					logger.Warnf("%d indexes missing: %s", len(missing), strings.Join(missing, ", "))
+					if fixMissing {
+						for _, m := range missing {
+							logger.Infof("Creating missing index %s", m)
+							store, err := nodeStores.GetStoreForNode(targetName)
+							if err != nil {
+								return err
+							}
+							err = store.CreateIndex(sourceIndexes[m])
+							if err != nil {
+								return err
+							}
+						}
+					}
 				}
 			}
 		}

--- a/internal/store/pgedge.go
+++ b/internal/store/pgedge.go
@@ -13,6 +13,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+type PgedgeNodeStores []*PgedgeNodeStore
+
 type PgedgeNodeStore struct {
 	Node  *model.PgedgeNode
 	Store *SQLStore
@@ -37,7 +39,7 @@ func NewStoreForPgedgeNode(db *model.PgedgeDatabase, node *model.PgedgeNode, log
 	return store, nil
 }
 
-func NewStoresForAllPgedgeNodes(pgedgeConfig *model.PgedgeClusterConfig, logger log.FieldLogger) ([]*PgedgeNodeStore, error) {
+func NewStoresForAllPgedgeNodes(pgedgeConfig *model.PgedgeClusterConfig, logger log.FieldLogger) (PgedgeNodeStores, error) {
 	nodes := pgedgeConfig.NodeGroups
 	if len(nodes) == 0 {
 		return nil, errors.New("config contains no database nodes")
@@ -57,4 +59,14 @@ func NewStoresForAllPgedgeNodes(pgedgeConfig *model.PgedgeClusterConfig, logger 
 	}
 
 	return nodesStores, nil
+}
+
+func (ns *PgedgeNodeStores) GetStoreForNode(name string) (*SQLStore, error) {
+	for _, nodeStore := range *ns {
+		if nodeStore.Node.Name == name {
+			return nodeStore.Store, nil
+		}
+	}
+
+	return nil, errors.Errorf("no node store for node %s", name)
 }


### PR DESCRIPTION
When using the verify-index command a flag is now provided which can be used to create database indexes on nodes where they are found to be missing.

Fixes https://mattermost.atlassian.net/browse/CLD-8845
