### PR TITLE
Don't exit monitoring when lag data error is encountered

### DIFF
--- a/internal/store/spock.go
+++ b/internal/store/spock.go
@@ -39,7 +39,6 @@ type SpockStatus struct {
 
 type SpockLagTracker struct {
 	SlotName        string `json:"slot_name" db:"slot_name"`
-	CommitLSN       string `json:"commit_lsn" db:"commit_lsn"`
 	CommitTimestamp string `json:"commit_timestamp" db:"commit_timestamp"`
 	ReplicationLag  string `json:"replication_lag" db:"replication_lag"`
 }
@@ -48,7 +47,7 @@ func init() {
 	spockVersionSelect = sq.Select("spock_version").From(spockVersionFunction)
 	spockVersionNumSelect = sq.Select("spock_version_num").From(spockVersionNumFunction)
 	spockReplicationSelect = sq.Select("subscription_name", "status", "replication_sets").From(spockReplicationFunction)
-	spockLagTrackerSelect = sq.Select("slot_name", "commit_lsn", "commit_timestamp", "replication_lag").From(spockLagTrackerTable)
+	spockLagTrackerSelect = sq.Select("slot_name", "commit_timestamp", "replication_lag").From(spockLagTrackerTable)
 }
 
 func (sqlStore *SQLStore) GetSpockVersion() (*SpockVersion, error) {

--- a/internal/tui/monitor.go
+++ b/internal/tui/monitor.go
@@ -132,9 +132,12 @@ func buildMonitorTable(nodeStores []*store.PgedgeNodeStore, includeMattermostDat
 			return nil, errors.Wrap(err, "failed to get spock replication status")
 		}
 
+		// Lag data is sometimes not present. Proceed without the data for
+		// each refresh cycle when an error is received.
+		spockLag := "n/a"
 		lag, err := nodeStore.Store.GetSpockLag()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get spock lag")
+		if err == nil {
+			spockLag = lag.ReplicationLag
 		}
 
 		connections, err := nodeStore.Store.GetConnectionCount()
@@ -147,7 +150,7 @@ func buildMonitorTable(nodeStores []*store.PgedgeNodeStore, includeMattermostDat
 			fmt.Sprintf("%s (%s)", version.Version, versionNum.VersionNum),
 			fmt.Sprintf("%d milliseconds", time.Since(start).Milliseconds()),
 			fmt.Sprintf("%s [%s]", status.SubscriptionName, status.Status),
-			fmt.Sprintf("%s [%s]", lag.CommitLSN, lag.ReplicationLag),
+			spockLag,
 			fmt.Sprintf("%d", connections),
 		}
 


### PR DESCRIPTION
The monitoring refresh loop normally exits on any error. In testing it seems like the Spock lag data is sometimes not available which leads to an error. This change alters the monitoring command so it will not exit and will attempt to pull the lag values in the next refresh.

Fixes https://mattermost.atlassian.net/browse/CLD-8847
